### PR TITLE
log support for systrace tool/plugin

### DIFF
--- a/examples/echo/Cargo.toml
+++ b/examples/echo/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 [dependencies]
 syscalls = { path = "../../syscalls" }
 tools_helper = { path = "../../tools_helper" }
+log = { version = "0.4", default-features = false }
 
 [build-dependencies]
 cc = "1.0.28"

--- a/examples/echo/src/lib.rs
+++ b/examples/echo/src/lib.rs
@@ -1,10 +1,19 @@
 #![feature(format_args_nl)]
 
-use syscalls::*;
 use tools_helper::*;
+use syscalls::*;
+use log::*;
 
 #[allow(unused_imports)]
 use std::ffi::CStr;
+
+#[cfg_attr(target_os = "linux", link_section = ".ctors")]
+pub static ECHO_DSO_CTORS: extern fn() = {
+    extern "C" fn echo_ctor() {
+	let _ = logger::init();
+    };
+    echo_ctor
+};
 
 #[no_mangle]
 pub extern "C" fn captured_syscall(
@@ -17,6 +26,10 @@ pub extern "C" fn captured_syscall(
     _a5: i64,
 ) -> i64 {
     let ret = unsafe { untraced_syscall(_no, _a0, _a1, _a2, _a3, _a4, _a5) };
-    msg!("{:?} = {:x?}", syscalls::SyscallNo::from(_no), ret);
+    if ret as u64 >= -4096i64 as u64 {
+        warn!("{:?} = {}", syscalls::SyscallNo::from(_no), ret);
+    } else {
+        info!("{:?} = {:x}", syscalls::SyscallNo::from(_no), ret);
+    }
     ret
 }

--- a/tools_helper/Cargo.toml
+++ b/tools_helper/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2018"
 
 [dependencies]
 syscalls = { path = "../syscalls" }
+log = { version = "0.4", default-features = false }

--- a/tools_helper/src/lib.rs
+++ b/tools_helper/src/lib.rs
@@ -1,7 +1,7 @@
-#![feature(format_args_nl)]
+#![feature(format_args_nl, slice_internals)]
 
 /// systrace tools helper
 #[macro_use]
 pub mod stdio;
 pub mod logger;
-
+pub mod spinlock;

--- a/tools_helper/src/logger.rs
+++ b/tools_helper/src/logger.rs
@@ -1,84 +1,97 @@
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
-pub enum Level {
-    Error = 0x1,
-    Warn,
-    Info,
-    Debug,
-    Trace
+/// safe logger for writing systrace tools (shared library)
+///
+/// log is enabled by passing `SYSTOOL_LOG=xxx` from systrace
+///
+/// NB: tools can use rust `log` crate, but must use this
+/// logger as backend. That is because logging in captured syscalls is
+/// very low level, roughly the same (or sligher higher) level as signal
+/// handlers, allocation should be reduced to minimum (if not none); and
+/// must also keep thread-safe in mind.
+///
+/// NB: any allocation (i.e.: `toString`) is considered DANGEROUS.
+/// we use a global static ring buffer to avoid allocations, and use CAS
+/// spinlocks to prevent race condition. note the same thread can call
+/// spin lock multiple times.
+///
+
+use log::{Log, Level, Metadata, Record, SetLoggerError};
+use core::fmt::{Arguments, Error, Write};
+
+use syscalls::*;
+use crate::spinlock::{SpinLock, SPINLOCK_INIT};
+
+const RING_BUFF_SIZE: usize = 16384;
+struct RingBuffer {
+    bytes: [u8; RING_BUFF_SIZE],
+    size: isize,
+    begin: isize,
+    end: isize,
+    is_empty: bool,
+    rawfd: i32,
+}
+static mut RING_BUFFER: RingBuffer = RingBuffer {
+    bytes: [0; RING_BUFF_SIZE],
+    size: RING_BUFF_SIZE as isize,
+    begin: 0,
+    end: 0,
+    is_empty: true,
+    rawfd: 2,
+};
+
+struct RingBufferLogger {}
+static LOGGER: RingBufferLogger = RingBufferLogger {};
+static LOGGER_LOCK: SpinLock = SPINLOCK_INIT;
+
+fn enter_critical_section() {
+    LOGGER_LOCK.lock();
 }
 
-pub fn log_enabled(level: Level) -> bool {
-    let log_level_ptr = 0x7000_1038 as *const i64;
-    let log_level = unsafe { core::ptr::read(log_level_ptr) };
-    log_level >= level as i64
+fn leave_critical_section() {
+    LOGGER_LOCK.unlock();
 }
 
-#[macro_export(local_inner_macros)]
-macro_rules! error {
-    (target: $target:expr, $($arg:tt)+) => (
-        log!(target: $target, $crate::logger::Level::Error, $($arg)+);
-    );
-    ($($arg:tt)+) => (
-        log!($crate::logger::Level::Error, $($arg)+);
-    )
-}
+fn update_buffer(rb: &mut RingBuffer, buffer: *const u8, n: isize, update_begin: bool) {
+    let ptr_begin = unsafe { rb.bytes.as_ptr().offset(rb.begin) };
+    let ptr_end   = unsafe { rb.bytes.as_ptr().offset(rb.end)   };
+    let ptr_min   = rb.bytes.as_ptr();
+    let ptr_max   = unsafe { rb.bytes.as_ptr().offset(rb.size)};
+    debug_assert!(ptr_begin >= ptr_min);
+    debug_assert!(ptr_end   <  ptr_max);
+    assert!(n <= rb.size);
 
-#[macro_export(local_inner_macros)]
-macro_rules! warn {
-    (target: $target:expr, $($arg:tt)+) => (
-        log!(target: $target, $crate::logger::Level::Warn, $($arg)+);
-    );
-    ($($arg:tt)+) => (
-        log!($crate::logger::Level::Warn, $($arg)+);
-    )
-}
+    if n == 0 { return; }
 
-#[macro_export(local_inner_macros)]
-macro_rules! info {
-    (target: $target:expr, $($arg:tt)+) => (
-        log!(target: $target, $crate::logger::Level::Info, $($arg)+);
-    );
-    ($($arg:tt)+) => (
-        log!($crate::logger::Level::Info, $($arg)+);
-    )
-}
+    rb.is_empty = false;
 
-#[macro_export(local_inner_macros)]
-macro_rules! debug {
-    (target: $target:expr, $($arg:tt)+) => (
-        log!(target: $target, $crate::logger::Level::Debug, $($arg)+);
-    );
-    ($($arg:tt)+) => (
-        log!($crate::logger::Level::Debug, $($arg)+);
-    )
-}
-
-#[macro_export(local_inner_macros)]
-macro_rules! trace {
-    (target: $target:expr, $($arg:tt)+) => (
-        log!(target: $target, $crate::logger::Level::Trace, $($arg)+);
-    );
-    ($($arg:tt)+) => (
-        log!($crate::logger::Level::Trace, $($arg)+);
-    )
-}
-
-#[macro_export(local_inner_macros)]
-macro_rules! log {
-    (target: $target:expr, $lvl:expr, $($arg:tt)+) => ({
-        let lvl = $lvl;
-        if $crate::logger::log_enabled(lvl) {
-            $crate::stdio::_eprint(__log_format_args!($($arg)+));
+    if rb.end + n < rb.size {
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                buffer,
+                ptr_end as *mut u8,
+                n as usize);
+        };
+        if update_begin {
+            rb.begin = rb.end;
         }
-    });
-    ($lvl:expr, $($arg:tt)+) => (log!(target: __log_module_path!(), $lvl, $($arg)+));
-}
-
-#[macro_export(local_inner_macros)]
-macro_rules! msg {
-    ($($arg:tt)*) => ({
-        $crate::stdio::_eprint(__log_format_args!($($arg)*));
-    })
+        rb.end += n;
+    } else {
+        let i = rb.size - rb.end;
+        let j = n - i;
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                buffer,
+                ptr_end as *mut u8,
+                i as usize);
+            core::ptr::copy_nonoverlapping(
+                buffer.offset(i),
+                ptr_min as *mut u8,
+                j as usize);
+        }
+        if update_begin {
+            rb.begin = rb.end;
+        }
+        rb.end = j;
+    }
 }
 
 #[doc(hidden)]
@@ -87,4 +100,133 @@ macro_rules! __log_format_args {
     ($($args:tt)*) => {
         format_args_nl!($($args)*)
     };
+}
+
+#[macro_export(local_inner_macros)]
+macro_rules! logmsg {
+    ($($arg:tt)*) => ({
+        $crate::logger::rb_eprint(__log_format_args!($($arg)*));
+    })
+}
+
+fn ll_write(rawfd: i32, buffer: *const u8, size: usize)
+{
+    unsafe {
+        untraced_syscall(SYS_write as i32, rawfd as i64, buffer as i64, size as i64, 0, 0, 0)
+    };
+}
+
+fn log_enabled(level: Level) -> bool {
+    let log_level_ptr = 0x7000_1038 as *const i64;
+    let log_level = unsafe { core::ptr::read(log_level_ptr) };
+    log_level >= level as i64
+}
+
+static LOG_LEVEL_STR: &[&str] = &[ "", "ERROR", "WARN", "INFO", "DEBUG", "TRACE" ];
+fn log_level_str(level: Level) -> &'static str {
+    let i = level as usize;
+    LOG_LEVEL_STR[i % 6]
+}
+
+impl Log for RingBufferLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        log_enabled(metadata.level())
+    }
+    fn log(&self, record: &Record) {
+        enter_critical_section();
+        if self.enabled(record.metadata()) {
+            logmsg!(
+                "[{:<5}] {}",
+                log_level_str(record.level()),
+                record.args());
+        }
+        leave_critical_section();
+    }
+    fn flush(&self) {
+        enter_critical_section();
+        unsafe {
+            flush_buffer(&mut RING_BUFFER, &ll_write)
+        };
+        leave_critical_section();
+    }
+}
+
+fn ring_buffer_write<F>(rb: &mut RingBuffer, s: &str, flush: F)
+where
+    F: Fn(i32, *const u8, usize),
+{
+    match core::slice::memchr::memrchr('\n' as u8, s.as_bytes()) {
+        None => update_buffer(rb, s.as_ptr(), s.len() as isize, false),
+        Some(i) => {
+            let i = 1 + i;
+            let j = s.len() - i;
+            let first = s.as_ptr();
+            let second = unsafe { first.offset(1 + i as isize) };
+            update_buffer(rb, first, i as isize, false);
+            flush_buffer(rb, flush);
+            update_buffer(rb, second, j as isize, false);
+        }
+    }
+}
+
+fn flush_buffer<F>(rb: &mut RingBuffer, flush: F)
+where
+    F: Fn(i32, *const u8, usize),
+{
+    if rb.is_empty { return; }
+    unsafe {
+        if rb.end > rb.begin {
+            flush(rb.rawfd, rb.bytes.as_ptr().offset(rb.begin), (rb.end - rb.begin) as usize);
+        } else {
+            let i = rb.size - rb.end;
+            let j = rb.size - (rb.begin - rb.end) - i;
+            flush(rb.rawfd, rb.bytes.as_ptr().offset(rb.begin), i as usize);
+            flush(rb.rawfd, rb.bytes.as_ptr(), j as usize);
+        }
+    };
+    rb.end = rb.begin;
+    rb.is_empty = true;
+}
+
+pub fn init() -> Result<(), SetLoggerError> {
+    let log_level_ptr = 0x7000_1038 as *const i64;
+    let log_level = unsafe { core::ptr::read(log_level_ptr) };
+    let level = match log_level {
+        1 => Some(Level::Error),
+        2 => Some(Level::Warn),
+        3 => Some(Level::Info),
+        4 => Some(Level::Debug),
+        5 => Some(Level::Trace),
+        _ => None,
+    };
+    log::set_logger(&LOGGER)?;
+    if let Some(lvl) = level {
+        log::set_max_level(lvl.to_level_filter());
+    }
+    Ok(())
+}
+
+impl Write for RingBuffer {
+    fn write_str(&mut self, s: &str) -> Result<(), Error> {
+        ring_buffer_write(self, s, ll_write);
+        Ok(())
+    }
+}
+
+fn rb_eprint(args: Arguments) {
+    unsafe {
+        rb_print_to(args, &mut RING_BUFFER)
+    };
+}
+
+fn rb_print_to(args: Arguments, file: &mut RingBuffer)
+{
+    core::fmt::write(file, args).expect("write failed");
+}
+
+#[macro_export(local_inner_macros)]
+macro_rules! msg {
+    ($($arg:tt)*) => ({
+        $crate::stdio::_eprint(__log_format_args!($($arg)*));
+    })
 }

--- a/tools_helper/src/logger.rs
+++ b/tools_helper/src/logger.rs
@@ -156,10 +156,10 @@ where
     F: Fn(i32, *const u8, usize),
 {
     match core::slice::memchr::memrchr('\n' as u8, s.as_bytes()) {
-        None => update_buffer(rb, s.as_ptr(), s.len() as isize, false),
+        None => update_buffer(rb, s.as_ptr(), s.bytes().len() as isize, false),
         Some(i) => {
             let i = 1 + i;
-            let j = s.len() - i;
+            let j = s.bytes().len() - i;
             let first = s.as_ptr();
             let second = unsafe { first.offset(1 + i as isize) };
             update_buffer(rb, first, i as isize, false);

--- a/tools_helper/src/spinlock.rs
+++ b/tools_helper/src/spinlock.rs
@@ -1,0 +1,94 @@
+///
+/// static spinlocks allow nested locking.
+/// the same thread can do nested spin locks, however
+/// there must be matching amount of spin unlocks
+/// unlock a lock locked by other thread will panic
+///
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use syscalls::*;
+
+pub struct SpinLock {
+    __lock: AtomicUsize,
+}
+
+const NEST_LEVEL_SHIFT: u32 = 48;
+#[allow(unused)]
+const NEST_LEVEL_MASK: usize = 0xffffusize.wrapping_shl(NEST_LEVEL_SHIFT);
+const THREAD_ID_SHIFT: u32 = 0;
+const THREAD_ID_MASK: usize = 0xffffffffffffusize;
+
+pub const SPINLOCK_INIT: SpinLock = SpinLock { __lock: AtomicUsize::new(0) };
+
+#[allow(unused)]
+fn nest_level(x: usize) -> usize {
+    (x & NEST_LEVEL_MASK).wrapping_shr(NEST_LEVEL_SHIFT)
+}
+
+fn thread_id(x: usize) -> usize {
+    (x & THREAD_ID_MASK).wrapping_shr(THREAD_ID_SHIFT)
+}
+
+fn level_tid(level: usize, tid: usize) -> usize {
+    level.wrapping_shl(NEST_LEVEL_SHIFT) | tid
+}
+
+fn inc_level(x: usize) -> usize {
+    x + 1usize.wrapping_shl(NEST_LEVEL_SHIFT)
+}
+
+fn dec_level(x: usize) -> usize {
+    x - 1usize.wrapping_shl(NEST_LEVEL_SHIFT)
+}
+
+impl SpinLock {
+    pub fn new() -> Self {
+        SpinLock { __lock: AtomicUsize::new(0) }
+    }
+    pub fn lock(&self) {
+        __spin_lock(&self.__lock);
+    }
+    pub fn unlock(&self) {
+        __spin_unlock(&self.__lock);
+    }
+}
+
+fn gettid() -> usize {
+    let tid = syscall(SYS_gettid as i32, 0, 0, 0, 0, 0, 0);
+    tid.unwrap() as usize
+}
+
+fn __spin_lock(lock: &AtomicUsize) {
+    let tid = gettid();
+
+    loop {
+        match lock
+            .compare_exchange(0,
+                              level_tid(1, tid),
+                              Ordering::Acquire,
+                              Ordering::Relaxed) {
+                Ok(_) => break,
+                Err(old) if thread_id(old) == tid => {
+                    lock.store(inc_level(old), Ordering::SeqCst);
+                    break;
+                }
+                _ => continue,
+        }
+    }
+}
+
+fn __spin_unlock(lock: &AtomicUsize) {
+    let tid = gettid();
+    let expected = level_tid(1, tid);
+    match lock.compare_exchange(
+        expected,
+        0,
+        Ordering::Release,
+        Ordering::Relaxed) {
+        Ok(_) => (),
+        Err(old) if thread_id(old) == tid => {
+            lock.store(dec_level(old), Ordering::SeqCst);
+        }
+        _ => panic!("trying to unlock a spinlock belongs to others"),
+    }
+}

--- a/tools_helper/src/stdio.rs
+++ b/tools_helper/src/stdio.rs
@@ -9,7 +9,7 @@ struct RawStdio {
 impl Write for RawStdio {
     fn write_str(&mut self, s: &str) -> Result<(), Error> {
         let fd = self.fileno;
-        let len = s.bytes().len();
+        let len = s.len();
         let buf: *const u8 = s.as_ptr();
         unsafe {
             untraced_syscall(SYS_write as i32, fd as i64, buf as i64, len as i64, 0, 0, 0)

--- a/tools_helper/src/stdio.rs
+++ b/tools_helper/src/stdio.rs
@@ -9,7 +9,7 @@ struct RawStdio {
 impl Write for RawStdio {
     fn write_str(&mut self, s: &str) -> Result<(), Error> {
         let fd = self.fileno;
-        let len = s.len();
+        let len = s.bytes().len();
         let buf: *const u8 = s.as_ptr();
         unsafe {
             untraced_syscall(SYS_write as i32, fd as i64, buf as i64, len as i64, 0, 0, 0)


### PR DESCRIPTION
This add potential logging support for `systrace` tools plugin (provided via `tools_helper::logger` crate). It is recommended because call generic logging API (such as `env_logger`) isn't considered safe, because the latter is too *high* level, and does allocations.

`tools_helper::logger` on the other hand doesn't use allocations, and it also uses spin locks for thread safety.

The (tool) log can be enabled by setting `SYSTOOL_LOG=xxx` for `systrace`.