### PR TITLE
combine trampoline.so and tool.so into a single dso

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [workspace]
 members= [".", "syscalls", "tools_helper", "examples/echo", "examples/none", "examples/counter"]
-default-members = [".", "syscalls", "tools_helper"]
+default-members = [".", "syscalls" ]
 
 [lib]
 name = "systrace"
@@ -30,5 +30,5 @@ log = "0.4"
 fern = "0.5"
 
 [build-dependencies]
-cc = "1.0.28"
+cc = "1.0"
 sysnum = { path = "sysnum" }

--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,9 @@ all:
 	@cp -v target/$(TARGETDIR)/systrace bin/
 clean:
 	$(MAKE) -C tests clean
-	$(RM) lib/libecho.so lib/libnone.so
+	$(RM) lib/lib*.so
 	$(RM) bin/systrace
-	@cargo clean --all
+	@cargo clean
 
 test: tests
 tests: all

--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,12 @@ endif
 all:
 	$(MAKE) -C tests all
 	@cargo build $(WAY) --all
-	@cp -v target/$(TARGETDIR)/libsystrace-trampoline.so lib/
 	@cp -v target/$(TARGETDIR)/libecho.so lib/
 	@cp -v target/$(TARGETDIR)/libnone.so lib/
 	@cp -v target/$(TARGETDIR)/systrace bin/
 clean:
 	$(MAKE) -C tests clean
-	$(RM) lib/libecho.so lib/libnone.so lib/libsystrace-trampoline.so
+	$(RM) lib/libecho.so lib/libnone.so
 	$(RM) bin/systrace
 	@cargo clean --all
 

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -15,4 +15,4 @@ tools_helper = { path = "../../tools_helper" }
 log = { version = "0.4", default-features = false }
 
 [build-dependencies]
-cc = "1.0.28"
+cc = "1.0"

--- a/examples/echo/Cargo.toml
+++ b/examples/echo/Cargo.toml
@@ -15,4 +15,4 @@ tools_helper = { path = "../../tools_helper" }
 log = { version = "0.4", default-features = false }
 
 [build-dependencies]
-cc = "1.0.28"
+cc = "1.0"

--- a/examples/none/Cargo.toml
+++ b/examples/none/Cargo.toml
@@ -11,5 +11,6 @@ path = "src/lib.rs"
 
 [dependencies]
 syscalls = { path = "../../syscalls" }
+tools_helper = { path = "../../tools_helper" }
 
 [build-dependencies]

--- a/examples/none/src/lib.rs
+++ b/examples/none/src/lib.rs
@@ -1,5 +1,8 @@
 use syscalls::*;
 
+#[allow(unused_imports)]
+use tools_helper::*;
+
 #[no_mangle]
 pub extern "C" fn captured_syscall(
     _no: i32,

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,5 +1,4 @@
-pub const LIBTRAMPOLINE_LIBRARY_PATH: &'static str = "LIBTRAMPOLINE_LIBRARY_PATH";
-pub const LIBTRAMPOLINE_SO: &'static str = "libsystrace-trampoline.so";
+pub const SYSTRACE_TRACEE_PRELOAD: &'static str = "SYSTRACE_TRACEE_PRELOAD";
 
 pub const SYSTRACE_ENV_TOOL_LOG_KEY: &'static str = "TOOL_LOG";
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,13 +287,6 @@ fn main() {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("library-path")
-                .long("library-path")
-                .value_name("LIBRARY_PATH")
-                .help("set library search path for systrace libraries such as libsystrace-trampoline.so")
-                .takes_value(true),
-        )
-        .arg(
             Arg::with_name("tool")
                 .long("tool")
                 .value_name("TOOL")

--- a/src/sched_wait.rs
+++ b/src/sched_wait.rs
@@ -122,6 +122,13 @@ fn ptracer_get_next(tasks: &mut SchedWait) -> Option<TracedTask> {
                         }
                         Ok(LinuxTaskState::Running) => continue,
                         Ok(LinuxTaskState::Ptraced) => continue,
+                        Err(_)                      => {
+                            log::debug!("[sched] {} vanished, assuming killed", tid);
+                            let status = wait::waitpid(Some(tid), None);
+                            log::trace!("[sched] {} {:?}", tid, status);
+                            assert_eq!(status, Ok(WaitStatus::PtraceEvent(tid, signal::SIGTRAP, 6)));
+                            let _ = ptrace::detach(tid);
+                        }
                         unknown => panic!("unknown state: {:?}", unknown),
                     }
                     break;

--- a/src/sched_wait.rs
+++ b/src/sched_wait.rs
@@ -127,6 +127,7 @@ fn ptracer_get_next(tasks: &mut SchedWait) -> Option<TracedTask> {
                             let status = wait::waitpid(Some(tid), None);
                             log::trace!("[sched] {} {:?}", tid, status);
                             assert_eq!(status, Ok(WaitStatus::PtraceEvent(tid, signal::SIGTRAP, 6)));
+                            let _ = tasks.tasks.remove(&tid);
                             let _ = ptrace::detach(tid);
                         }
                         unknown => panic!("unknown state: {:?}", unknown),

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -98,7 +98,7 @@ clean:
 
 tests: build-tests
 	./x64-save-return-address
-	$(SYSTRACE_DEBUG) ./openat1
+	$(SYSTRACE_DEBUG) RUST_BACKTRACE=1 ./openat1
 	$(SYSTRACE_DEBUG) ./open-many > /dev/null
 	$(SYSTRACE_DEBUG) ./write-many
 	$(SYSTRACE_DEBUG) ./getpid

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -9,8 +9,8 @@ TARGET  := x64-save-return-address openat1 open-many getpid write-many forkExec 
 
 SYSTRACE_LIBRARY_PATH := $(shell realpath $(shell pwd)/../target/debug)
 SYSTRACE_TOOL         := $(shell realpath $(shell pwd)/../target/debug/libnone.so)
-SYSTRACE_DEBUG := $(shell realpath ../bin/systrace) --library-path=$(SYSTRACE_LIBRARY_PATH) --tool=$(SYSTRACE_TOOL) --debug=4 --
-SYSTRACE       := $(shell realpath ../bin/systrace) --library-path=$(SYSTRACE_LIBRARY_PATH) --tool=$(SYSTRACE_TOOL) --debug=0 --
+SYSTRACE_DEBUG := $(shell realpath ../bin/systrace) --tool=$(SYSTRACE_TOOL) --debug=4 --
+SYSTRACE       := $(shell realpath ../bin/systrace) --tool=$(SYSTRACE_TOOL) --debug=0 --
 
 all: $(TARGET)
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,8 +5,8 @@ LD	 = lld
 CFLAGS	 = -g -Wall -O2 -D_POSIX_C_SOURCE=20180920 -D_GNU_SOURCE=1 -fPIC
 CXXFLAGS = -g -Wall -O2 -D_POSIX_C_SOURCE=20180920 -D_GNU_SOURCE=1 -std=c++1z -fPIC
 
-TARGET  := x64-save-return-address openat1 open-many getpid write-many forkExec clock-nanosleep threads1 threads2 threads3 getpid-pie nanosleep segfault threads4 threads5 threads6 threads7 forkMany signal1 signal2 signal3 signal4 sigprocmask1
-
+TARGET  := x64-save-return-address openat1 open-many getpid write-many forkExec clock-nanosleep threads1 threads2 threads3 getpid-pie nanosleep segfault threads4 threads5 threads6 threads7 forkMany signal1 signal2 signal3 signal4 sigprocmask1 thread8-cond-wait.c thread9-cond-bcast
+ 
 SYSTRACE_LIBRARY_PATH := $(shell realpath $(shell pwd)/../target/debug)
 SYSTRACE_TOOL         := $(shell realpath $(shell pwd)/../target/debug/libnone.so)
 SYSTRACE_DEBUG := $(shell realpath ../bin/systrace) --tool=$(SYSTRACE_TOOL) --debug=4 --
@@ -74,6 +74,12 @@ threads6: threads6.o
 threads7: threads7.o
 	$(CC) $^ -o $@ $(CFLAGS) -lrt -lpthread
 
+thread8-cond-wait: thread8-cond-wait.o
+	$(CC) $^ -o $@ $(CFLAGS) -lrt -lpthread
+
+thread9-cond-bcast: thread9-cond-bcast.o
+	$(CC) $^ -o $@ $(CFLAGS) -lrt -lpthread
+
 segfault: segfault.o
 	$(CC) $^ -o $@ $(CFLAGS) -lrt -lpthread
 
@@ -121,5 +127,6 @@ tests: build-tests
 	./signal2
 	./signal3
 	./sigprocmask1
+	$(SYSTRACE_DEBUG) ./pthread8-cond-wait
 
 .PHONY: all tests clean

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,7 +5,7 @@ LD	 = lld
 CFLAGS	 = -g -Wall -O2 -D_POSIX_C_SOURCE=20180920 -D_GNU_SOURCE=1 -fPIC
 CXXFLAGS = -g -Wall -O2 -D_POSIX_C_SOURCE=20180920 -D_GNU_SOURCE=1 -std=c++1z -fPIC
 
-TARGET  := x64-save-return-address openat1 open-many getpid write-many forkExec clock-nanosleep threads1 threads2 threads3 getpid-pie nanosleep segfault threads4 threads5 threads6 threads7 forkMany signal1 signal2 signal3 signal4 sigprocmask1 thread8-cond-wait.c thread9-cond-bcast
+TARGET  := x64-save-return-address openat1 open-many getpid write-many forkExec clock-nanosleep threads1 threads2 threads3 getpid-pie nanosleep segfault threads4 threads5 threads6 threads7 forkMany signal1 signal2 signal3 signal4 sigprocmask1 thread8-cond-wait thread9-cond-bcast
  
 SYSTRACE_LIBRARY_PATH := $(shell realpath $(shell pwd)/../target/debug)
 SYSTRACE_TOOL         := $(shell realpath $(shell pwd)/../target/debug/libnone.so)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -98,7 +98,7 @@ clean:
 
 tests: build-tests
 	./x64-save-return-address
-	$(SYSTRACE_DEBUG) RUST_BACKTRACE=1 ./openat1
+	RUST_BACKTRACE=1 $(SYSTRACE_DEBUG) ./openat1
 	$(SYSTRACE_DEBUG) ./open-many > /dev/null
 	$(SYSTRACE_DEBUG) ./write-many
 	$(SYSTRACE_DEBUG) ./getpid

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -127,6 +127,7 @@ tests: build-tests
 	./signal2
 	./signal3
 	./sigprocmask1
-	$(SYSTRACE_DEBUG) ./pthread8-cond-wait
+	$(SYSTRACE_DEBUG) ./thread8-cond-wait
+	$(SYSTRACE_DEBUG) ./thread9-cond-bcast
 
 .PHONY: all tests clean

--- a/tests/thread8-cond-wait.c
+++ b/tests/thread8-cond-wait.c
@@ -1,0 +1,66 @@
+#include <sys/types.h>
+#include <pthread.h>
+#include <time.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(x)    ( (sizeof(x)) / sizeof((x)[0]) )
+#endif
+
+#define NR_THREADS 5
+
+static pthread_cond_t conds[NR_THREADS] = {
+  PTHREAD_COND_INITIALIZER,
+  PTHREAD_COND_INITIALIZER,
+  PTHREAD_COND_INITIALIZER,
+  PTHREAD_COND_INITIALIZER,
+  PTHREAD_COND_INITIALIZER,
+};
+
+static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+
+void* thread_entry(void* param)
+{
+  long id = (long)param;
+
+  printf("this is thread #%lu\n", id);
+
+  pthread_mutex_lock(&mutex);
+
+  pthread_cond_wait(&conds[id], &mutex);
+  pthread_cond_signal(&conds[(1+id) % NR_THREADS]);
+
+  pthread_mutex_unlock(&mutex);
+
+  printf("%lu exited.\n", id);
+
+  return 0;
+}
+
+int main(int argc, char* argv[])
+{
+  pthread_t ids[NR_THREADS];
+  struct timespec tp = {0, 100000000};
+
+  for (long i = 0; i < NR_THREADS; i++) {
+    pthread_create(&ids[i], NULL, thread_entry, (void*)i);
+  }
+
+  nanosleep(&tp, NULL);
+
+  int k = 3;
+  printf("signaling thread #%u\n", k);
+  pthread_cond_signal(&conds[k]);
+
+  for (int i = 0; i < NR_THREADS; i++) {
+    pthread_join(ids[i], NULL);
+  }
+
+  for (int i = 0; i < NR_THREADS; i++) {
+    pthread_cond_destroy(&conds[i]);
+  }
+
+  return 0;
+}
+

--- a/tests/thread9-cond-bcast.c
+++ b/tests/thread9-cond-bcast.c
@@ -1,0 +1,69 @@
+#include <sys/types.h>
+#include <pthread.h>
+#include <time.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(x)    ( (sizeof(x)) / sizeof((x)[0]) )
+#endif
+
+#define NR_THREADS 5
+
+static pthread_cond_t conds[NR_THREADS] = {
+  PTHREAD_COND_INITIALIZER,
+  PTHREAD_COND_INITIALIZER,
+  PTHREAD_COND_INITIALIZER,
+  PTHREAD_COND_INITIALIZER,
+  PTHREAD_COND_INITIALIZER,
+};
+
+static pthread_mutex_t mutexes[NR_THREADS] = {
+  PTHREAD_MUTEX_INITIALIZER,
+  PTHREAD_MUTEX_INITIALIZER,
+  PTHREAD_MUTEX_INITIALIZER,
+  PTHREAD_MUTEX_INITIALIZER,
+  PTHREAD_MUTEX_INITIALIZER,
+};
+
+void* thread_entry(void* param)
+{
+  long id = (long)param;
+
+  printf("this is thread #%lu\n", id);
+
+  pthread_mutex_lock(&mutexes[0]);
+
+  pthread_cond_wait(&conds[0], &mutexes[0]);
+
+  pthread_mutex_unlock(&mutexes[0]);
+
+  printf("%lu exited.\n", id);
+
+  return 0;
+}
+
+int main(int argc, char* argv[])
+{
+  pthread_t ids[NR_THREADS];
+  struct timespec tp = {0, 100000000};
+
+  for (long i = 0; i < NR_THREADS; i++) {
+    pthread_create(&ids[i], NULL, thread_entry, (void*)i);
+  }
+
+  nanosleep(&tp, NULL);
+
+  pthread_cond_broadcast(&conds[0]);
+
+  for (int i = 0; i < NR_THREADS; i++) {
+    pthread_join(ids[i], NULL);
+  }
+
+  for (int i = 0; i < NR_THREADS; i++) {
+    pthread_cond_destroy(&conds[i]);
+  }
+
+  return 0;
+}
+

--- a/tools_helper/Cargo.toml
+++ b/tools_helper/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2018"
 [dependencies]
 syscalls = { path = "../syscalls" }
 log = { version = "0.4", default-features = false }
+
+[build-dependencies]
+cc = "1.0"

--- a/tools_helper/build.rs
+++ b/tools_helper/build.rs
@@ -1,5 +1,15 @@
 
+use cc;
+
 fn main() {
     std::fs::copy("../src/consts.rs", "src/consts.rs").unwrap();
     std::fs::copy("../src/state.rs", "src/state.rs").unwrap();
+    cc::Build::new()
+        .flag("-Wall").flag("-fPIC").flag("-O2")
+        .flag("-D_POSIX_C_SOURCE=20180920").flag("-D_GNU_SOURCE=1")
+        .flag("-I../include").flag("-I../trampoline")
+        .file("../trampoline/trampoline.S")
+        .file("../trampoline/raw_syscall.S")
+        .file("../trampoline/route.c")
+        .compile("my-trampoline-lib");
 }


### PR DESCRIPTION
This PR is trying to merge `libsystrace-trampoline.so` and `lib<TOOL>.so` into a single shared library: `lib<TOOL>.so`. Since both libraries relies on each other and must be loaded by `systrace`, merge them seems intuitive, and it also simplifies the command line interface (no more `--library-path`).