### PR TITLE
bug fix: syscall patch + benchmarks

### DIFF
--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -7,7 +7,7 @@ ECHO	 = /bin/echo
 CFLAGS	 = -g -Wall -O2 -D_POSIX_C_SOURCE=20180920 -D_GNU_SOURCE=1 -fPIC
 CXXFLAGS = -g -Wall -O2 -D_POSIX_C_SOURCE=20180920 -D_GNU_SOURCE=1 -std=c++1z -fPIC
 
-TARGET  := getpid getpid-many getpid-many-threaded gettime-many
+TARGET  := getpid getpid-many getpid-many-threaded getpid-many-threaded2 gettime-many
 
 SYSTRACE_LIBRARY_PATH := $(shell realpath $(shell pwd)/../target/debug)
 SYSTRACE_TOOL         := $(shell realpath $(shell pwd)/../target/debug/libnone.so)
@@ -34,6 +34,9 @@ getpid-many: getpid-many.o
 	$(CC) $^ -o $@ $(CFLAGS)
 
 getpid-many-threaded: getpid-many-threaded.o
+	$(CC) $^ -o $@ $(CFLAGS) -lpthread
+
+getpid-many-threaded2: getpid-many-threaded2.o
 	$(CC) $^ -o $@ $(CFLAGS) -lpthread
 
 gettime-many: gettime-many.o


### PR DESCRIPTION
it is normal `mmap` could return the same virtual address after `munmap`, however, they might point to different physical memory. so we shouldn't assume the patch work is done just because the virtual addresses are the same.